### PR TITLE
api key expiry message made client dependent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .Renviron
 .RData
 .Rproj.user
-..Rcheck
+*Rcheck
+*.tar.gz
 .DS_Store
 inst/doc
 testscript.R

--- a/R/gor_connect.R
+++ b/R/gor_connect.R
@@ -32,8 +32,8 @@ gor_connect <- function(api_key, project, api_endpoint = "/api/query") {
         gorr__failure("Authentication error", paste(
             "API key expired at",
             as.character(expiry_date),
-            "\n     Please get a new one at: ",
-            with(service_url_parts, stringr::str_glue("{scheme}://{hostname}/api-key-service/token"))
+            if (token_payload$azp == "api-key-client")
+                with(service_url_parts, stringr::str_glue("\n     Please get a new one at: {scheme}://{hostname}/api-key-service/token"))
         ))
     }
 


### PR DESCRIPTION
On using an expired refresh token, the message pointing users towards api key service for a new refresh token will now only show if the client is api-key-client, this message will then not show for other clients such as jupyterhub

*Rcheck, and .tar.gz added to .gitignore