### PR TITLE
calling gor_connect() with no parameters now supported

### DIFF
--- a/R/gor_connect.R
+++ b/R/gor_connect.R
@@ -15,8 +15,16 @@
 #' api_key <- "...paste from your /api-key-service/token endpoint..."
 #' conn <- gor_connect(api_key, "test_project")
 #' }
-gor_connect <- function(api_key, project, api_endpoint = "/api/query") {
-    assert_that(is.string(api_key))
+gor_connect <- function(api_key = NULL, project = NULL, api_endpoint = "/api/query") {
+    if (is.null(api_key)) {
+        api_key <- Sys.getenv("GOR_API_KEY")
+        if (api_key == "") gorr__failure("api_key not provided, the alternative GOR_API_KEY environment variable is not set")
+    }
+    if (is.null(project)) {
+        project <- Sys.getenv("GOR_API_PROJECT")
+        if (project == "") gorr__failure("project not provided, the alternative GOR_API_PROJECT environment variable is not set")
+    }
+
 
     token_payload <- get_jwt_token_payload(api_key)
     expiry_date <- lubridate::as_datetime(token_payload$exp)

--- a/R/gor_query.R
+++ b/R/gor_query.R
@@ -29,8 +29,8 @@ gorr__api_request <- function(request.fun = c("POST", "GET", "DELETE"),
 #'
 #' @examples
 #' \dontrun{
-#' api_key <- Sys.getenv("GORR_API_KEY")
-#' project <- Sys.getenv("GORR_PROJECT")
+#' api_key <- Sys.getenv("GOR_API_KEY")
+#' project <- Sys.getenv("GOR_PROJECT")
 #' conn <- gor_connect(api_key, project)
 #' "gor #dbsnp# | top 100" %>%
 #'     gor_query(conn)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,8 +2,8 @@ library(testthat)
 library(assertthat)
 library(gorr)
 
-if (!all(c("GORR_API_KEY", "GORR_API_PROJECT") %in% names(Sys.getenv())))
-    stop("GORR_API_KEY and GORR_API_PROJECT environment variables have not been set")
-
-
-test_check("gorr")
+if (!all(c("GOR_API_KEY", "GOR_API_PROJECT") %in% names(Sys.getenv()))) {
+    message("GOR_API_KEY and GOR_API_PROJECT environment variables have not been set, skipping API tests")
+} else {
+     test_check("gorr")
+}

--- a/tests/testthat/test-gor_query.R
+++ b/tests/testthat/test-gor_query.R
@@ -5,8 +5,17 @@ conn <- NULL
 
 test_that("gor_connect works", {
     conn <<- gor_connect(
-        api_key = Sys.getenv("GORR_API_KEY"),
-        project = Sys.getenv("GORR_API_PROJECT"))
+        api_key = Sys.getenv("GOR_API_KEY"),
+        project = Sys.getenv("GOR_API_PROJECT"))
+    expect_is(conn, "gor_connection")
+    expect_true(!is.null(conn$header))
+    expect_true(!is.null(conn$header$headers[["authorization"]]))
+
+})
+
+
+test_that("gor_connect works without parameters", {
+    conn <- gor_connect()
     expect_is(conn, "gor_connection")
     expect_true(!is.null(conn$header))
     expect_true(!is.null(conn$header$headers[["authorization"]]))
@@ -22,6 +31,8 @@ test_that("gor_query works", {
     expect_equal(colnames(result), c("Chrom", "pos", "reference", "allele", "rsids"))
     expect_equal(dim(result), c(100,5), info = "Expected dimensions of this dataframe are 100rows x 5 columns")
 })
+
+
 
 test_that("gor_query paging works", {
     result <-

--- a/vignettes/basic-query.Rmd
+++ b/vignettes/basic-query.Rmd
@@ -34,8 +34,8 @@ library(tibble)
 First we'll need to establish a connection to our direct query API. To do that we'll need to call `gor_connect` and provide it with the relevant parameters pointing to the direct-query-service, i.e. `api_key` and `project`:
 
 ```{r}
-api_key <- Sys.getenv("GORR_API_KEY")
-conn <- gor_connect(api_key, project = Sys.getenv("GORR_API_PROJECT"))
+api_key <- Sys.getenv("GOR_API_KEY")
+conn <- gor_connect(api_key, project = Sys.getenv("GOR_API_PROJECT"))
 conn
 ```
 


### PR DESCRIPTION
it will pull the required information from the environment variables GOR_API_KEY GOR_API_PROJECT instead