### PR TITLE
Fixes query cancellation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gorr
 Title: GOR Direct Query API for R
-Version: 0.2.8
+Version: 0.2.9
 Authors@R: c(
     person("WuXi", "Nextcode", role = c("aut", "cre"), email = "support@wuxinextcode.com"),
     person("Edvald", "Gislason", role = "aut", email = "edvald@wuxinextcode.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gorr 0.2.9
 
+Killing queries now works as expected 
+
 # gorr 0.2.8
 
 Using API keys from other client-ids now works, i.e. removed hard-coding of client-id in access token request.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gorr 0.2.9
+
 # gorr 0.2.8
 
 Using API keys from other client-ids now works, i.e. removed hard-coding of client-id in access token request.

--- a/R/gor_query.R
+++ b/R/gor_query.R
@@ -95,7 +95,7 @@ gor_query <- function(query, conn, timeout = 0, page_size = 100e3, parse = T) {
 
         result
     },
-    interrupt = function(err) gorr__kill_query(query_id, conn),
+    interrupt = function(err) gorr__kill_query(query_response$links$self, conn),
     error = stop)
 }
 


### PR DESCRIPTION
error due to incomplete refactoring, didn't get caught since gorr__kill_query isn't covered in tests.