### PR TITLE
Verify token

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gorr
 Title: GOR Direct Query API for R
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("WuXi", "Nextcode", role = c("aut", "cre"), email = "support@wuxinextcode.com"),
     person("Edvald", "Gislason", role = "aut", email = "edvald@wuxinextcode.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gorr 0.3.1
+
 # gorr 0.3.0
 
 * Virtual relations feature implemented, allowing referencing local data frame (via upload), and maintaining GOR create statements and definitions.

--- a/R/get_access_token.R
+++ b/R/get_access_token.R
@@ -19,7 +19,14 @@ get_access_token <- function(api_key, url) {
 
     response <- httr::POST(url, body = body, encode = "form")
     if (response$status_code != 200) {
-        gorr__failure("Unable to connect to authentication service",
+        content <- httr::content(response)
+        error_message <- if (!is.null(content$error_description))  {
+            content$error_description
+        } else {
+            "Unable to connect to authentication service"
+        }
+
+        gorr__failure(error_message,
                       paste("HTTP Status Code", response$status_code, httr::message_for_status(response$status_code)))
     }
 

--- a/R/gor_query.R
+++ b/R/gor_query.R
@@ -280,8 +280,8 @@ gorr__failure <- function(msg, detail = NULL) {
             detail <- paste(names(detail), detail, sep = ": ", collapse = "\n    ")
 
         stop(paste(crayon::red(msg), "\nDetails: \n    ", detail), call. = F)
+    } else {
+        stop(crayon::red(msg), call. = F)
     }
-
-    stop(crayon::red(msg), call. = F)
 }
 


### PR DESCRIPTION
 * HTTP errors from the authentication service are now correctly displayed to the user detailing the error message received instead of showing a generic HTTP XXX error

* if the payload part of the token is invalid, the client will throw an error explaining that.

