### PR TITLE
virtual relations errors fixed and render_only query 

### DIFF
--- a/R/gor_create.R
+++ b/R/gor_create.R
@@ -47,7 +47,7 @@ gor_create <- function(..., defs = NULL, conn = NULL, replace = NULL) {
 
     dots <- purrr::discard(dots, is.null)
 
-    fn <- function(query, ...) {
+    fn <- function(query, render_only = F, ...) {
         # evaluating the dots inside this function is necessary, otherwise virtual relations are fixed.
         relations <- lapply(dots, eval, parent.frame())
         # Pick out virtual relations
@@ -65,6 +65,10 @@ gor_create <- function(..., defs = NULL, conn = NULL, replace = NULL) {
         query <- c(def_statements, create_statements, query) %>%
             purrr::discard(function(x) is.null(x) || x == "") %>%
             paste(collapse = "\n")
+
+        if (render_only)
+            return(query)
+
         gor_query(query, conn = conn, relations = virtual_relations, ...)
     }
 


### PR DESCRIPTION
* the query closure returned by gor_create now supports the parameter render_only which will simply return the final rendered query as string instead of executing it

* Virtual relation errors properly communicated to the user