### PR TITLE
COHO-1102:  handle null exp in jwt token

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,11 @@
 Type: Package
 Package: gorr
 Title: GOR Direct Query API for R
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(
-    person("WuXi", "Nextcode", role = c("aut", "cre"), email = "support@wuxinextcode.com"),
-    person("Edvald", "Gislason", role = "aut", email = "edvald@wuxinextcode.com")
+    person("Genuity", "Science", role = c("aut", "cre","cph"), email = "support@genuitysci.com"),
+    person("Edvald", "Gislason", role = "aut", email = ""),
+    person("Ólafur", "Flygenring", role = "ctb", email = "olafurh@genuitysci.com")
     )
 URL: https://github.com/wuxi-nextcode/gorr
 BugReports: https://github.com/wuxi-nextcode/gorr/issues

--- a/R/gor_connect.R
+++ b/R/gor_connect.R
@@ -43,7 +43,7 @@ gor_connect <- function(api_key = NULL, project = NULL, root_url = NULL, api_end
     }
 
     token_payload <- get_jwt_token_payload(api_key)
-    expiry_date <- if (is.null(token_payload)) NULL else lubridate::as_datetime(token_payload$exp)
+    expiry_date <- if (is.null(token_payload) || is.null(token_payload$exp)) NULL else lubridate::as_datetime(token_payload$exp)
     if (is.null(root_url)) {
         root_url_env <- Sys.getenv("GOR_API_ROOT_URL")
         root_url <- if (root_url_env == "") token_payload$iss else root_url_env
@@ -54,7 +54,7 @@ gor_connect <- function(api_key = NULL, project = NULL, root_url = NULL, api_end
     service_url_parts$path <- api_endpoint
     service_root <- httr::build_url(service_url_parts)
 
-    if (!is.null(token_payload) && token_payload$exp > 0 && expiry_date <= lubridate::now()) {
+    if (!is.null(token_payload) && !is.null(expiry_date) > 0 && (expiry_date <= lubridate::now())) {
         gorr__failure("Authentication error", paste(
             "API key expired at",
             as.character(expiry_date),

--- a/R/gor_connect.R
+++ b/R/gor_connect.R
@@ -54,7 +54,7 @@ gor_connect <- function(api_key = NULL, project = NULL, root_url = NULL, api_end
     service_url_parts$path <- api_endpoint
     service_root <- httr::build_url(service_url_parts)
 
-    if (!is.null(token_payload) && !is.null(expiry_date) > 0 && (expiry_date <= lubridate::now())) {
+    if (!is.null(expiry_date) && (expiry_date <= lubridate::now())) {
         gorr__failure("Authentication error", paste(
             "API key expired at",
             as.character(expiry_date),


### PR DESCRIPTION
* We now handle JWT tokens that have no exp field.
* Updated authors
* Bumped patch version